### PR TITLE
Update README with what the gem is; fix formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ By [Tinfoil Security](http://tinfoilsecurity.com/)
 
 [![Build Status](https://travis-ci.org/tinfoil/shoulda-kept-assign-to.svg?branch=master)](https://travis-ci.org/tinfoil/shoulda-kept-assign-to)
 
-Shoulda-matchers ([official Git repo](https://github.com/thoughtbot/shoulda-matchers)) removed the `assign_to` matcher in version 2.0.0. We missed it dearly; enough to bring it back. This gem adds the `assign_to` matcher back in and includes, by reference, all the rest of the `shoulda-matchers` – just the way it was before it was mercilessly destroyed.
+Shoulda-matchers ([official Git repo](https://github.com/thoughtbot/shoulda-matchers)) removed the `assign_to` matcher in version 2.0.0. We missed it dearly, enough to bring it back. This gem adds the `assign_to` matcher back in and includes, by reference, all the rest of the `shoulda-matchers` – just the way it was before it was mercilessly destroyed.
 
 ## Example (from shoulda-matchers, v1.5)
 
@@ -26,7 +26,7 @@ end
 In Rails 3 and Bundler, add the following to your Gemfile:
 
 ```ruby
-group :development, :test do
+group :test do
   gem "shoulda-kept-assign-to"
 end
 ```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ By [Tinfoil Security](http://tinfoilsecurity.com/)
 
 [![Build Status](https://travis-ci.org/tinfoil/shoulda-kept-assign-to.svg?branch=master)](https://travis-ci.org/tinfoil/shoulda-kept-assign-to)
 
-Shoulda-matchers ([official Git repo](https://github.com/thoughtbot/shoulda-matchers)) removed the `assign_to` matcher in version 2.0.0. We missed it dearly; enough to bring it back. This gem adds the `assign_to` matcher back in, just the way it was before it was mercilessly destroyed.
+Shoulda-matchers ([official Git repo](https://github.com/thoughtbot/shoulda-matchers)) removed the `assign_to` matcher in version 2.0.0. We missed it dearly; enough to bring it back. This gem adds the `assign_to` matcher back in and includes, by reference, all the rest of the `shoulda-matchers` – just the way it was before it was mercilessly destroyed.
 
 ## Example (from shoulda-matchers, v1.5)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ By [Tinfoil Security](http://tinfoilsecurity.com/)
 
 [![Build Status](https://travis-ci.org/tinfoil/shoulda-kept-assign-to.svg?branch=master)](https://travis-ci.org/tinfoil/shoulda-kept-assign-to)
 
-Shoulda-matchers, ([official Git repo](https://github.com/thoughtbot/shoulda-matchers)), removed the assign_to matcher in version 2.0.0. We missed it dearly, enough to bring it back. This gem includes all of the current version of shoulda-matchers, and it adds the 'assign_to' matcher back in, just the way it was before it was mercilessly destroyed.
+Shoulda-matchers, ([official Git repo](https://github.com/thoughtbot/shoulda-matchers)), removed the assign_to matcher in version 2.0.0. We missed it dearly, enough to bring it back. This gem adds the 'assign_to' matcher back in, just the way it was before it was mercilessly destroyed.
 
 ## Example (from shoulda-matchers, v1.5)
 
@@ -26,8 +26,10 @@ end
 In Rails 3 and Bundler, add the following to your Gemfile:
 
 ```ruby
-group :test do
+group :development, :test do
+  gem "shoulda-matchers"
   gem "shoulda-kept-assign-to"
 end
+```
 
 Shoulda will automatically include matchers into the appropriate example groups.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ By [Tinfoil Security](http://tinfoilsecurity.com/)
 
 [![Build Status](https://travis-ci.org/tinfoil/shoulda-kept-assign-to.svg?branch=master)](https://travis-ci.org/tinfoil/shoulda-kept-assign-to)
 
-Shoulda-matchers, ([official Git repo](https://github.com/thoughtbot/shoulda-matchers)), removed the assign_to matcher in version 2.0.0. We missed it dearly, enough to bring it back. This gem adds the 'assign_to' matcher back in, just the way it was before it was mercilessly destroyed.
+Shoulda-matchers ([official Git repo](https://github.com/thoughtbot/shoulda-matchers)) removed the `assign_to` matcher in version 2.0.0. We missed it dearly; enough to bring it back. This gem adds the `assign_to` matcher back in, just the way it was before it was mercilessly destroyed.
 
 ## Example (from shoulda-matchers, v1.5)
 
@@ -27,7 +27,6 @@ In Rails 3 and Bundler, add the following to your Gemfile:
 
 ```ruby
 group :development, :test do
-  gem "shoulda-matchers"
   gem "shoulda-kept-assign-to"
 end
 ```


### PR DESCRIPTION
Addresses #6.

I think I see now what you were trying to get at, as the gem depends on `shoulda-matchers` so you don't need to specify it separately. 
