### PR TITLE
Fix deprectation warning in Rspec 2.99 when using a matcher

### DIFF
--- a/lib/shoulda/matchers/action_controller/assign_to_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/assign_to_matcher.rb
@@ -96,7 +96,7 @@ module Shoulda # :nodoc:
 
         def equal_to_expected_value?
           if @options[:check_value]
-            if @options[:expected_value] == assigned_value
+            if @options[:expected_value] === assigned_value
               @failure_message_when_negated =
                 "Didn't expect action to assign #{@options[:expected_value].inspect} " <<
                 "for #{@variable}, but got it anyway"

--- a/spec/shoulda/matchers/action_controller/assign_to_matcher_spec.rb
+++ b/spec/shoulda/matchers/action_controller/assign_to_matcher_spec.rb
@@ -50,8 +50,12 @@ describe Shoulda::Matchers::ActionController::AssignToMatcher do
       controller.should_not assign_to(:var).in_context(self).with { expected }
     end
 
+    it 'accepts assigning a matcher for the value to that variable' do
+      controller.should assign_to(:arr).with(match_array(['value', 'other']))
+    end
+
     def controller
-      build_response { @var = 'value' }
+      build_response { @var = 'value'; @arr = ['other', 'value'] }
     end
   end
 


### PR DESCRIPTION
When running this in a project using Rspec 2.99, I get the following warning:

```
Deprecation Warnings:

Using `matcher == value` as an alias for `#matches?` is deprecated. Use `matcher === value` instead. Called from ~/Source/shoulda-kept-assign-to/lib/shoulda/matchers/action_controller/assign_to_matcher.rb:99:in `equal_to_expected_value?'.
```

This happens when using a matcher as the `with` parameter, rather than just a value.

```ruby
      controller.should assign_to(:arr).with(match_array(['value', 'other']))
```

This PR fixes it by changing to the `===` syntax suggested in the warning. This works fine with the existing appraisal set, under Rspec 2.14 without any problems.

To test with Rspec 2.99 I changed the `.gemspec` as follows:

```diff
diff --git a/shoulda-kept-assign-to.gemspec b/shoulda-kept-assign-to.gemspec
index 10c02b0..daa9958 100644
--- a/shoulda-kept-assign-to.gemspec
+++ b/shoulda-kept-assign-to.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('appraisal')
   s.add_development_dependency('rails', '~> 3')
   s.add_development_dependency('sqlite3')
-  s.add_development_dependency('rspec-rails')
+  s.add_development_dependency('rspec-rails', '~> 2.99.0')
 end
```